### PR TITLE
fix: foundry repo broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <img src="src/images/foundry-banner.png" style="border-radius: 20px">
 
-<br>
-
 # 📖 Foundry ZKsync Book
 
-A book on all things foundry ZKsync. [Read now](https://foundry-book.zksync.io/).
-
+A book on all things Foundry ZKsync. [Read now](https://foundry-book.zksync.io/).

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@
 
 Foundry-ZKsync manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line and via Solidity scripts.
 
-> ⚠️ **Alpha Stage:** The project is in alpha, so you might encounter issues. For more information or reporting bugs, please visit the [Foundry-ZKsync GitHub repository](https://github.com/matter-labs/foundry-zksync-foundry).
+> ⚠️ **Alpha Stage:** The project is in alpha, so you might encounter issues. For more information or reporting bugs, please visit the [Foundry-ZKsync GitHub repository](https://github.com/matter-labs/foundry-zksync).
 
 ## Sections
 **[Getting Started](getting-started/installation.md)**


### PR DESCRIPTION
Quick fix for the ZKsync foundry repo link, annoying because it's on the introduction space