### PR TITLE
fix: disable root-summary from output generation

### DIFF
--- a/scripts/gen_output/help.sh
+++ b/scripts/gen_output/help.sh
@@ -11,10 +11,10 @@ gen_help() {
     echo "Generating help output ($bin)..."
   done
 
+  # Disable --root-summary until we wish to support adding CLI references
   cmd=(
     "$SCRIPTS/gen_output/help.py"
     --root-dir "$ROOT/src/"
-    --root-summary
     --root-indentation 4
     --readme
     --out-dir "$ROOT/src/reference/cli/"

--- a/src/reference/README.md
+++ b/src/reference/README.md
@@ -1,11 +1,11 @@
 ## References
 
-- [CLI Reference](./cli/)
-- [forge Commands](./forge/)
-- [cast Commands](./cast/)
-- [anvil Reference](./anvil/)
-- [chisel Reference](./chisel/)
+<!-- - [CLI Reference](./cli/) -->
+<!-- - [forge Commands](./forge/) -->
+<!-- - [cast Commands](./cast/) -->
+<!-- - [anvil Reference](./anvil/) -->
+<!-- - [chisel Reference](./chisel/) -->
 - [Config Reference](./config/)
-- [Cheatcodes Reference](../cheatcodes/)
-- [Forge Standard Library Reference](./forge-std)
-- [ds-test Reference](./ds-test.md)
+<!-- - [Cheatcodes Reference](../cheatcodes/) -->
+<!-- - [Forge Standard Library Reference](./forge-std) -->
+<!-- - [ds-test Reference](./ds-test.md) -->


### PR DESCRIPTION
If enabled this will currently overwrite `SUMMARY.md` and uncomment the disabled section.