### PR TITLE
fix: fix link in repo

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@
 
 Foundry-ZKsync manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line and via Solidity scripts.
 
-> ⚠️ **Alpha Stage:** The project is in alpha, so you might encounter issues. For more information or reporting bugs, please visit the [Foundry-ZKsync GitHub repository](https://github.com/matter-labs/foundry-zksync-foundry).
+> ⚠️ **Alpha Stage:** The project is in alpha, so you might encounter issues. For more information or reporting bugs, please visit the [Foundry-ZKsync GitHub repository](https://github.com/matter-labs/foundry-zksync).
 
 ## Sections
 **[Getting Started](getting-started/installation.md)**


### PR DESCRIPTION
- Fixes the link to point to foundry-zksync correctly