### PR TITLE
Use TestExt interface to call zkUsePaymaster

### DIFF
--- a/src/zksync-specifics/cheatcodes/zk-use-paymaster.md
+++ b/src/zksync-specifics/cheatcodes/zk-use-paymaster.md
@@ -13,13 +13,19 @@ This cheatcode enables the use of a paymaster for the next transaction in the co
 ### Examples
 
 ```solidity
-MyPaymaster paymaster = new MyPaymaster();
-// Encode paymaster input
-bytes memory paymaster_encoded_input = abi.encodeWithSelector(
-    bytes4(keccak256("general(bytes)")),
-    bytes("0x")
-);
-vm.zkUsePaymaster(address(paymaster), paymaster_encoded_input);
+import {TestExt} from "forge-zksync-std/TestExt.sol";
+
+contract Test is TestExt {
+    function test_zkUsePaymaster() public {
+        MyPaymaster paymaster = new MyPaymaster();
+        // Encode paymaster input
+        bytes memory paymaster_encoded_input = abi.encodeWithSelector(
+            bytes4(keccak256("general(bytes)")),
+            bytes("0x")
+        );
+        vmExt.zkUsePaymaster(address(paymaster), paymaster_encoded_input);
+    }
+}
 ```
 
 The paymaster flow depends on the type of paymaster used. Here's an example of the simplest usage of a 'general' paymaster in Foundry:
@@ -80,7 +86,7 @@ forge create ./src/MyPaymaster.sol:MyPaymaster --rpc-url {RPC_URL} --private-key
 3. Use the cheatcode to set the paymaster for the next transaction:
 
 ```solidity
-vm.zkUsePaymaster(address(paymaster), abi.encodeWithSelector(
+vmExt.zkUsePaymaster(address(paymaster), abi.encodeWithSelector(
     bytes4(keccak256("general(bytes)")),
     bytes("0x")
 ));

--- a/src/zksync-specifics/examples/paymaster-approval-based.md
+++ b/src/zksync-specifics/examples/paymaster-approval-based.md
@@ -35,8 +35,11 @@ Now, in the script we are going to run, we deploy the contract and mint some tok
 ```solidity
 import {Script} from "forge-std/Script.sol";
 import {console2} from "../lib/forge-std/src/console2.sol";
+// We need to import the TestExt to use the zkUsePaymaster cheatcode
+// as this is a ZKsync specific cheatcode
+import {TestExt} from "forge-zksync-std/TestExt.sol";
 
-contract PaymasterApprovalScript is Script {
+contract PaymasterApprovalScript is Script, TestExt {
     function run() external {
         vm.startBroadcast();
 
@@ -65,7 +68,7 @@ With the encoded input prepared, we can now use the zkUsePaymaster cheatcode to 
 
 ```solidity
 // Using zkUsePaymaster with the encoded input
-vm.zkUsePaymaster(address(0x3cB2b87D10Ac01736A65688F3e0Fb1b070B3eeA3), paymaster_encoded_input);
+vmExt.zkUsePaymaster(address(0x3cB2b87D10Ac01736A65688F3e0Fb1b070B3eeA3), paymaster_encoded_input);
 
 Counter counter = new Counter();
 counter.increment();
@@ -82,8 +85,12 @@ pragma solidity ^0.8.0;
 import {Script} from "forge-std/Script.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+// We need to import the TestExt to use the zkUsePaymaster cheatcode
+// as this is a ZKsync specific cheatcode
+import {TestExt} from "forge-zksync-std/TestExt.sol";
 
-contract PaymasterTestScript is Script {
+
+contract PaymasterTestScript is Script, TestExt {
     function run() external {
         vm.startBroadcast();
 


### PR DESCRIPTION
We were not using the right interface to call zksync specific cheat codes which lead users to confusion. 