### PR TITLE
docs: Uncomment config reference

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -422,8 +422,8 @@
   - [`anvil-zksync` Reference](./reference/anvil-zksync/README.md)
   <!-- - [`chisel` Reference](./reference/chisel/README.md) -->
   - [Config Reference](./reference/config/README.md)
-    - [Overview](./reference/config/overview.md)
-    - [Project](./reference/config/project.md)
+  - [Overview](./reference/config/overview.md)
+  - [Project](./reference/config/project.md)
     <!-- - [Solidity Compiler](./reference/config/solidity-compiler.md) -->
     - [Testing](./reference/config/testing.md)
     <!-- - [In-line Configuration Testing](./reference/config/inline-test-config.md) -->

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -419,12 +419,12 @@
       - [cast wallet verify](./reference/cast/cast-wallet-verify.md)
       - [cast wallet import](./reference/cast/cast-wallet-import.md)
       - [cast wallet list](./reference/cast/cast-wallet-list.md) -->
-  - [`anvil-zksync` Reference](./reference/anvil-zksync/README.md) -->
-  <!-- - [`chisel` Reference](./reference/chisel/README.md)
+  - [`anvil-zksync` Reference](./reference/anvil-zksync/README.md)
+  <!-- - [`chisel` Reference](./reference/chisel/README.md) -->
   - [Config Reference](./reference/config/README.md)
     - [Overview](./reference/config/overview.md)
     - [Project](./reference/config/project.md)
-    - [Solidity Compiler](./reference/config/solidity-compiler.md)
+    <!-- - [Solidity Compiler](./reference/config/solidity-compiler.md) -->
     - [Testing](./reference/config/testing.md)
     <!-- - [In-line Configuration Testing](./reference/config/inline-test-config.md) -->
     <!-- - [Formatter](./reference/config/formatter.md) -->


### PR DESCRIPTION
uncommented the Config reference link in the SUMMARY.md file to fix broken links like https://foundry-book.zksync.io/config/?highlight=foundry.toml#configuring-with-foundrytoml