### PR TITLE
Fix incorrect directory name in installation instructions

### DIFF
--- a/vocs/docs/pages/introduction/installation.md
+++ b/vocs/docs/pages/introduction/installation.md
@@ -69,7 +69,7 @@ Or, by manually building from a local copy of the [Foundry-ZKsync repository](ht
 ```sh
 # clone the repository
 git clone https://github.com/matter-labs/foundry-zksync.git
-cd foundry
+cd foundry-zksync
 # install Forge
 cargo install --path ./crates/forge --profile release --force --locked
 # install Cast


### PR DESCRIPTION
docs: fix incorrect directory name in installation instructions

The installation guide currently suggests running `cd foundry` after cloning `foundry-zksync`. This causes an error because the cloned directory is actually named `foundry-zksync`.

Updated the documentation to use `cd foundry-zksync` to ensure consistency and prevent setup errors.